### PR TITLE
Remove unused Autowired import

### DIFF
--- a/src/main/java/com/hampcode/controller/BookController.java
+++ b/src/main/java/com/hampcode/controller/BookController.java
@@ -5,7 +5,6 @@ import com.hampcode.dto.BookRequest;
 import com.hampcode.service.BookService;
 
 import org.springframework.web.bind.annotation.*;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 


### PR DESCRIPTION
## Summary
- remove the unused `@Autowired` import in `BookController`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb1fcfd7c832ea418e4afa2e265d4