### PR TITLE
Add Author service and controller tests

### DIFF
--- a/src/test/java/com/hampcode/AuthorControllerTests.java
+++ b/src/test/java/com/hampcode/AuthorControllerTests.java
@@ -1,0 +1,40 @@
+package com.hampcode;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthorControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DirtiesContext
+    void createAuthorEndpointReturnsCreatedAuthor() throws Exception {
+        String body = "{\"name\":\"Laura Restrepo\"}";
+        mockMvc.perform(post("/api/v1/authors")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").isNumber())
+                .andExpect(jsonPath("$.name").value("Laura Restrepo"));
+    }
+
+    @Test
+    void searchAuthorsByNameReturnsList() throws Exception {
+        mockMvc.perform(get("/api/v1/authors/search")
+                .param("name", "Gabriel"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Gabriel García Márquez"));
+    }
+}

--- a/src/test/java/com/hampcode/AuthorServiceTests.java
+++ b/src/test/java/com/hampcode/AuthorServiceTests.java
@@ -1,0 +1,48 @@
+package com.hampcode;
+
+import com.hampcode.dto.AuthorRequest;
+import com.hampcode.model.Author;
+import com.hampcode.service.AuthorService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class AuthorServiceTests {
+
+    @Autowired
+    private AuthorService authorService;
+
+    @Test
+    @DirtiesContext
+    void createNewAuthorReturnsAuthor() {
+        int initialSize = authorService.findAll().size();
+        AuthorRequest req = new AuthorRequest("Julio Cortazar");
+        Author created = authorService.create(req);
+        assertThat(created).isNotNull();
+        assertThat(created.getId()).isNotNull();
+        assertThat(created.getName()).isEqualTo("Julio Cortazar");
+        assertThat(authorService.findAll()).hasSize(initialSize + 1);
+    }
+
+    @Test
+    @DirtiesContext
+    void createDuplicateAuthorReturnsNull() {
+        AuthorRequest req = new AuthorRequest("Gabriel García Márquez");
+        Author created = authorService.create(req);
+        assertThat(created).isNull();
+        assertThat(authorService.findAll()).hasSize(2);
+    }
+
+    @Test
+    void findByNameReturnsMatches() {
+        List<Author> results = authorService.findByName("Isabel");
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getName()).isEqualTo("Isabel Allende");
+    }
+}


### PR DESCRIPTION
## Summary
- add `AuthorServiceTests` verifying create and search operations
- add `AuthorControllerTests` using MockMvc for REST endpoints

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_683fb1ffa384832eac9e6a6a940c3a2f